### PR TITLE
Add simple Flutter app with image capture and webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.dart_tool/
+build/

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,11 @@
+# Flutter N8N Image Uploader
+
+This simple Flutter project captures an image and sends it with form data as JSON to an n8n webhook.
+
+## Usage
+
+1. Replace the placeholder webhook URL in `lib/main.dart` with your n8n webhook endpoint.
+2. Run the app on a device or emulator.
+3. Enter a name and description, capture an image, then tap **Send** to post the data.
+
+The app encodes the image to Base64 and posts a JSON payload containing the text fields and image data.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: ImageCapturePage(),
+    );
+  }
+}
+
+class ImageCapturePage extends StatefulWidget {
+  const ImageCapturePage({super.key});
+
+  @override
+  State<ImageCapturePage> createState() => _ImageCapturePageState();
+}
+
+class _ImageCapturePageState extends State<ImageCapturePage> {
+  final _picker = ImagePicker();
+  XFile? _image;
+  final _nameController = TextEditingController();
+  final _descController = TextEditingController();
+
+  Future<void> _captureImage() async {
+    final image = await _picker.pickImage(source: ImageSource.camera);
+    if (image != null) {
+      setState(() {
+        _image = image;
+      });
+    }
+  }
+
+  Future<void> _sendData() async {
+    if (_image == null) return;
+
+    final bytes = await _image!.readAsBytes();
+    final base64Image = base64Encode(bytes);
+
+    final body = jsonEncode({
+      'name': _nameController.text,
+      'description': _descController.text,
+      'image': base64Image,
+    });
+
+    final url = Uri.parse('https://your-n8n-webhook.url/webhook');
+    await http.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: body,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Capture & Send')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            TextField(
+              controller: _descController,
+              decoration: const InputDecoration(labelText: 'Description'),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: Center(
+                child: _image != null
+                    ? Image.file(File(_image!.path))
+                    : const Placeholder(),
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                ElevatedButton(
+                  onPressed: _captureImage,
+                  child: const Text('Capture'),
+                ),
+                const SizedBox(width: 16),
+                ElevatedButton(
+                  onPressed: _sendData,
+                  child: const Text('Send'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,19 @@
+name: viettire_app
+description: Simple Flutter app to capture an image and send it with form data to an n8n webhook.
+publish_to: 'none'
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.13.6
+  image_picker: ^1.0.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add minimal Flutter project that captures an image and sends JSON payload to an n8n webhook
- document usage in README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896c6712c6483289d4ddaf22f14c74c